### PR TITLE
fixes bug of large headings overlaying on small mobil

### DIFF
--- a/dist/about.html
+++ b/dist/about.html
@@ -27,7 +27,7 @@
         </div>
         <ul class="menu-nav">
           <li class="nav-item">
-            <a href="index.html" class="nav-link">Home</a>
+            <a href="../index.html" class="nav-link">Home</a>
           </li>
           <li class="nav-item current">
             <a href="about.html" class="nav-link">About me</a>

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -280,7 +280,9 @@ main {
     grid-template-columns: repeat(2, 1fr); } }
 
 @media screen and (max-width: 500px) {
-  main#home h1 {
-    margin-top: 10vh; }
+  main h1.lg-heading {
+    font-size: 3rem; }
+  main h1#home {
+    margin-top: 5vh; }
   .projects {
     grid-template-columns: 1fr; } }

--- a/scss/mobile.scss
+++ b/scss/mobile.scss
@@ -70,9 +70,18 @@
 }
 
 @include mediaSm {
-    main#home h1 {
-        margin-top: 10vh;
+    main h1 {
+        
+        &.lg-heading {
+            font-size: 3rem;
+        }
+
+        &#home {
+            margin-top: 5vh;
+        }
+
     }
+
 
     .projects {
         grid-template-columns: 1fr;


### PR DESCRIPTION
### What does this PR do?
It fixes the large screen overlay bug error

The previous image on mobile 

![error](https://user-images.githubusercontent.com/44635784/86058111-0798ac80-ba69-11ea-9dc1-b71ff34aa4d6.jpeg)

The current situation resolved
![solution](https://user-images.githubusercontent.com/44635784/86058206-2eef7980-ba69-11ea-80cd-c4cadb5355ca.png)

**Steps**
Edit CSS styling on all headings on responsive to change to 3rem for small mobile phone view.
Maintain the styling for heading h1 under the main id to 5vh below the top through a margin 5vh  
